### PR TITLE
Bug: Missing  [ @post = Post.new(post_params) ]

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,7 +23,7 @@ class PostsController < ApplicationController
 	end
 
 	def update
-
+                @post = Post.new(post_params)
 		if @post.update(post_params)
 			redirect_to @post
 		else


### PR DESCRIPTION
I found this bug, the syntax to find the particular post based on id was missing.